### PR TITLE
[Feat] 채팅방 정렬 및 읽음 처리 기능 구현 #11

### DIFF
--- a/src/main/java/com/example/chatserver/common/entity/ChatMessage.java
+++ b/src/main/java/com/example/chatserver/common/entity/ChatMessage.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "messages")
+@Table(name = "chat_messages")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseEntity {
 

--- a/src/main/java/com/example/chatserver/common/entity/ChatRoom.java
+++ b/src/main/java/com/example/chatserver/common/entity/ChatRoom.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "chat_rooms", uniqueConstraints = @UniqueConstraint(columnNames = {"property_id", "bidder_id", "seller_id"}))
@@ -23,6 +25,13 @@ public class ChatRoom extends BaseEntity {
 
     @Column(name = "property_id", nullable = false)
     private Long propertyId;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    public void updateLastMessageAt(LocalDateTime time) {
+        this.lastMessageAt = time;
+    }
 
     private ChatRoom(Long sellerId, Long bidderId, Long propertyId) {
         this.sellerId = sellerId;

--- a/src/main/java/com/example/chatserver/common/entity/ReadState.java
+++ b/src/main/java/com/example/chatserver/common/entity/ReadState.java
@@ -1,0 +1,50 @@
+package com.example.chatserver.common.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "read_states", uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"}))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReadState {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Column(name="user_id", nullable = false)
+    private Long userId;
+
+    @Column(name="last_read_message_id")
+    private Long lastReadMessageId;
+
+    @Column(name="unread_count", nullable = false)
+    private long unreadCount;
+
+    private ReadState(ChatRoom chatRoom, Long userId, Long lastReadMessageId, long unreadCount) {
+        this.chatRoom = chatRoom;
+        this.userId = userId;
+        this.lastReadMessageId = lastReadMessageId;
+        this.unreadCount = unreadCount;
+    }
+
+    public static ReadState create(ChatRoom chatRoom, Long userId) {
+        return new ReadState(chatRoom, userId, null, 0);
+    }
+
+    public void increaseUnreadCount() {
+        this.unreadCount++;
+    }
+
+    public void markRead(Long lastReadMessageId) {
+        this.lastReadMessageId = lastReadMessageId;
+        this.unreadCount = 0;
+    }
+}

--- a/src/main/java/com/example/chatserver/domain/chatMessage/controller/ChatMessageController.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/controller/ChatMessageController.java
@@ -1,12 +1,17 @@
 package com.example.chatserver.domain.chatMessage.controller;
 
 import com.example.chatserver.common.entity.ChatMessage;
+import com.example.chatserver.common.entity.ChatRoom;
 import com.example.chatserver.domain.chatMessage.dto.payload.ChatMessagePayload;
 import com.example.chatserver.domain.chatMessage.dto.request.SendMessageRequest;
 import com.example.chatserver.domain.chatMessage.dto.response.GetMessageResponse;
 import com.example.chatserver.domain.chatMessage.service.ChatMessageService;
 import com.example.chatserver.domain.chatMessage.dto.request.SendFirstMessageRequest;
 import com.example.chatserver.domain.chatMessage.dto.response.SendFirstMessageResponse;
+import com.example.chatserver.domain.chatRoom.repository.ChatRoomRepository;
+import com.example.chatserver.domain.readState.dto.payload.ReadStatePayload;
+import com.example.chatserver.domain.readState.dto.request.MarkReadRequest;
+import com.example.chatserver.domain.readState.service.ReadStateService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +28,8 @@ import org.springframework.web.bind.annotation.*;
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
+    private final ReadStateService readStateService;
+    private final ChatRoomRepository chatRoomRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
     // 첫 메시지 전송 + 방 생성
@@ -47,6 +54,33 @@ public class ChatMessageController {
                 receiverId.toString(),
                 "/queue/chat",
                 ChatMessagePayload.from(savedMessage)
+        );
+
+        messagingTemplate.convertAndSendToUser(
+                request.getSenderId().toString(),
+                "/queue/chat",
+                ChatMessagePayload.from(savedMessage)
+        );
+    }
+
+    // 메시지 읽음
+    @MessageMapping("/read")
+    public void markRead(MarkReadRequest request) {
+
+        Long roomId = request.getRoomId();
+        Long readerId = request.getUserId();
+
+        Long lastReadMessageId = readStateService.markReadAll(roomId, readerId);
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalStateException("채팅방이 존재하지 않습니다."));
+
+        Long otherId = readerId.equals(room.getSellerId()) ? room.getBidderId() : room.getSellerId();
+
+        messagingTemplate.convertAndSendToUser(
+                otherId.toString(),
+                "/queue/read",
+                new ReadStatePayload(roomId, readerId, lastReadMessageId)
         );
     }
 

--- a/src/main/java/com/example/chatserver/domain/chatMessage/dto/payload/ChatMessagePayload.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/dto/payload/ChatMessagePayload.java
@@ -4,15 +4,19 @@ import com.example.chatserver.common.entity.ChatMessage;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 public class ChatMessagePayload {
 
+    private Long messageId;
     private Long roomId;
     private Long senderId;
     private String content;
+    private LocalDateTime createdAt;
 
     public static ChatMessagePayload from(ChatMessage message) {
-        return new ChatMessagePayload(message.getChatRoom().getId(), message.getSenderId(), message.getContent());
+        return new ChatMessagePayload(message.getId(), message.getChatRoom().getId(), message.getSenderId(), message.getContent(), message.getCreatedAt());
     }
 }

--- a/src/main/java/com/example/chatserver/domain/chatMessage/dto/response/GetMessageResponse.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/dto/response/GetMessageResponse.java
@@ -11,12 +11,14 @@ import java.time.LocalDateTime;
 public class GetMessageResponse {
 
     private Long messageId;
+    private Long senderId;
     private String content;
     private LocalDateTime createdAt;
 
     public static GetMessageResponse from(ChatMessage message) {
         return new GetMessageResponse(
                 message.getId(),
+                message.getSenderId(),
                 message.getContent(),
                 message.getCreatedAt()
         );

--- a/src/main/java/com/example/chatserver/domain/chatMessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/repository/ChatMessageRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
 
     Slice<ChatMessage> findByChatRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
+
+    Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long roomId);
 }

--- a/src/main/java/com/example/chatserver/domain/chatMessage/service/ChatMessageService.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/service/ChatMessageService.java
@@ -1,5 +1,6 @@
 package com.example.chatserver.domain.chatMessage.service;
 
+import com.example.chatserver.common.entity.ReadState;
 import com.example.chatserver.domain.chatMessage.dto.payload.ChatMessagePayload;
 import com.example.chatserver.domain.chatMessage.dto.request.SendFirstMessageRequest;
 import com.example.chatserver.domain.chatMessage.dto.request.SendMessageRequest;
@@ -9,6 +10,7 @@ import com.example.chatserver.common.entity.ChatRoom;
 import com.example.chatserver.common.entity.ChatMessage;
 import com.example.chatserver.domain.chatRoom.repository.ChatRoomRepository;
 import com.example.chatserver.domain.chatMessage.repository.ChatMessageRepository;
+import com.example.chatserver.domain.readState.repository.ReadStateRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +27,7 @@ public class ChatMessageService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ReadStateRepository readStateRepository;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     // 첫 메시지 전송 + 방 생성
@@ -61,6 +64,12 @@ public class ChatMessageService {
 
             savedRoom.updateLastMessageAt(savedMessage.getCreatedAt());
 
+            ReadState sellerState = readStateRepository.save(ReadState.create(savedRoom, sellerId));
+            sellerState.increaseUnreadCount();
+
+            ReadState bidderState = readStateRepository.save(ReadState.create(savedRoom, bidderId));
+            bidderState.markRead(savedMessage.getId());
+
             simpMessagingTemplate.convertAndSendToUser(
                     sellerId.toString(),
                     "/queue/chat",
@@ -92,6 +101,16 @@ public class ChatMessageService {
         ChatMessage savedMessage = chatMessageRepository.save(message);
 
         room.updateLastMessageAt(savedMessage.getCreatedAt());
+
+        Long receiverId = senderId.equals(room.getSellerId()) ? room.getBidderId() : room.getSellerId();
+
+        ReadState receiverState = readStateRepository.findByChatRoomAndUserId(room, receiverId)
+                .orElseGet(() -> readStateRepository.save(ReadState.create(room, receiverId)));
+        receiverState.increaseUnreadCount();
+
+        ReadState senderState = readStateRepository.findByChatRoomAndUserId(room, senderId)
+                .orElseGet(() -> readStateRepository.save(ReadState.create(room, senderId)));
+        senderState.markRead(savedMessage.getId());
 
         return savedMessage;
     }

--- a/src/main/java/com/example/chatserver/domain/chatMessage/service/ChatMessageService.java
+++ b/src/main/java/com/example/chatserver/domain/chatMessage/service/ChatMessageService.java
@@ -46,7 +46,7 @@ public class ChatMessageService {
             throw new IllegalStateException("판매자와 입찰자는 동일할 수 없습니다.");
         }
 
-        Optional<ChatRoom> existingRoom = chatRoomRepository.findByPropertyIdAndBidderIdAndSellerId(propertyId, bidderId, senderId);
+        Optional<ChatRoom> existingRoom = chatRoomRepository.findByPropertyIdAndBidderIdAndSellerId(propertyId, bidderId, sellerId);
 
         if (existingRoom.isPresent()) {
             throw new IllegalStateException("이미 채팅방이 존재합니다.");
@@ -58,6 +58,8 @@ public class ChatMessageService {
 
             ChatMessage message = ChatMessage.create(senderId, savedRoom, content);
             ChatMessage savedMessage = chatMessageRepository.save(message);
+
+            savedRoom.updateLastMessageAt(savedMessage.getCreatedAt());
 
             simpMessagingTemplate.convertAndSendToUser(
                     sellerId.toString(),
@@ -87,7 +89,11 @@ public class ChatMessageService {
         }
 
         ChatMessage message = ChatMessage.create(senderId, room, request.getContent());
-        return chatMessageRepository.save(message);
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+
+        room.updateLastMessageAt(savedMessage.getCreatedAt());
+
+        return savedMessage;
     }
 
     public Long getReceiverId(ChatMessage message) {

--- a/src/main/java/com/example/chatserver/domain/chatRoom/dto/response/GetMyRoomsResponse.java
+++ b/src/main/java/com/example/chatserver/domain/chatRoom/dto/response/GetMyRoomsResponse.java
@@ -10,11 +10,12 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class GetMyRoomsResponse {
 
-    // TODO: 채팅 제목, 최근 채팅 전송 시간 추가
     private Long roomId;
-    private LocalDateTime createdAt;
+    private LocalDateTime lastMessageAt;
+    private Long unreadCount;
+    private Long lastReadMessageId;
 
-    public static GetMyRoomsResponse from(ChatRoom room) {
-        return new GetMyRoomsResponse(room.getId(), room.getCreatedAt());
+    public static GetMyRoomsResponse from(ChatRoom room, Long unreadCount, Long lastReadMessageId) {
+        return new GetMyRoomsResponse(room.getId(), room.getLastMessageAt(), unreadCount, lastReadMessageId);
     }
 }

--- a/src/main/java/com/example/chatserver/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/chatserver/domain/chatRoom/repository/ChatRoomRepository.java
@@ -11,5 +11,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
 
     Optional<ChatRoom> findByPropertyIdAndBidderIdAndSellerId(Long propertyId, Long bidderId, Long sellerId);
 
-    Slice<ChatRoom> findBySellerIdOrBidderIdOrderByIdDesc(Long sellerId, Long bidderId, Pageable pageable);
+    Slice<ChatRoom> findBySellerIdOrBidderIdOrderByLastMessageAtDesc(Long sellerId, Long bidderId, Pageable pageable);
 }

--- a/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
@@ -4,12 +4,10 @@ import com.example.chatserver.domain.chatRoom.dto.request.FindRoomRequest;
 import com.example.chatserver.domain.chatRoom.dto.response.GetMyRoomsResponse;
 import com.example.chatserver.domain.chatRoom.dto.response.FindRoomResponse;
 import com.example.chatserver.domain.chatRoom.repository.ChatRoomRepository;
-import com.example.chatserver.domain.chatMessage.repository.ChatMessageRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +18,6 @@ import java.util.Optional;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatMessageRepository messageRepository;
-    private final SimpMessagingTemplate simpMessagingTemplate;
 
     // 이미 존재하는 채팅방인지 검증
     @Transactional

--- a/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
     public Slice<GetMyRoomsResponse> getMyRooms(Long userId, Pageable pageable) {
 
         return chatRoomRepository
-                .findBySellerIdOrBidderIdOrderByIdDesc(userId, userId, pageable)
+                .findBySellerIdOrBidderIdOrderByLastMessageAtDesc(userId, userId, pageable)
                 .map(GetMyRoomsResponse::from);
     }
 }

--- a/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/example/chatserver/domain/chatRoom/service/ChatRoomService.java
@@ -1,9 +1,12 @@
 package com.example.chatserver.domain.chatRoom.service;
 
+import com.example.chatserver.common.entity.ChatRoom;
+import com.example.chatserver.common.entity.ReadState;
 import com.example.chatserver.domain.chatRoom.dto.request.FindRoomRequest;
 import com.example.chatserver.domain.chatRoom.dto.response.GetMyRoomsResponse;
 import com.example.chatserver.domain.chatRoom.dto.response.FindRoomResponse;
 import com.example.chatserver.domain.chatRoom.repository.ChatRoomRepository;
+import com.example.chatserver.domain.readState.repository.ReadStateRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -11,13 +14,18 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static java.util.stream.Collectors.toMap;
 
 @Service
 @RequiredArgsConstructor
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ReadStateRepository readStateRepository;
 
     // 이미 존재하는 채팅방인지 검증
     @Transactional
@@ -32,8 +40,57 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public Slice<GetMyRoomsResponse> getMyRooms(Long userId, Pageable pageable) {
 
-        return chatRoomRepository
-                .findBySellerIdOrBidderIdOrderByLastMessageAtDesc(userId, userId, pageable)
-                .map(GetMyRoomsResponse::from);
+        Slice<ChatRoom> rooms = chatRoomRepository.findBySellerIdOrBidderIdOrderByLastMessageAtDesc(userId, userId, pageable);
+
+        List<ChatRoom> roomList = rooms.getContent();
+
+        if (roomList.isEmpty()) {
+            return rooms.map(room -> GetMyRoomsResponse.from(room, 0L, null));
+        }
+
+        List<Long> roomIds = roomList.stream().map(ChatRoom::getId).toList();
+
+        // 내 ReadState 조회
+        List<ReadState> myReadStates = readStateRepository.findByChatRoomIdInAndUserId(roomIds, userId);
+
+        Map<Long, ReadState> myReadStateMap = myReadStates.stream()
+                .collect(toMap(
+                        rs -> rs.getChatRoom().getId(),
+                        rs -> rs
+                ));
+
+        // 상대 ReadState 조회
+        List<Long> otherUserIds = roomList.stream()
+                .map(room -> userId.equals(room.getSellerId()) ? room.getBidderId() : room.getSellerId())
+                .distinct()
+                .toList();
+
+        List<ReadState> otherReadStates = readStateRepository.findByChatRoomIdInAndUserIdIn(roomIds, otherUserIds);
+
+        // (roomId, userId) 조합으로 구분하기 위해 문자열 키 사용하여 합체
+        Map<String, ReadState> otherReadStateMap = otherReadStates.stream()
+                .collect(toMap(
+                        rs -> key(rs.getChatRoom().getId(), rs.getUserId()),
+                        rs -> rs
+                ));
+
+        return rooms.map(room -> {
+
+            // 내가 읽지 않은 메시지 수
+            ReadState myState = myReadStateMap.get(room.getId());
+            long unreadCount = (myState == null) ? 0 : myState.getUnreadCount();
+
+            // 상대가 어디까지 읽었는지
+            Long otherUserId = userId.equals(room.getSellerId()) ? room.getBidderId() : room.getSellerId();
+
+            ReadState otherState = otherReadStateMap.get(key(room.getId(), otherUserId));
+            Long otherLastReadMessageId = (otherState == null) ? null : otherState.getLastReadMessageId();
+
+            return GetMyRoomsResponse.from(room, unreadCount, otherLastReadMessageId);
+        });
+    }
+
+    private String key(Long roomId, Long userId) {
+        return roomId + ":" + userId;
     }
 }

--- a/src/main/java/com/example/chatserver/domain/readState/dto/payload/ReadStatePayload.java
+++ b/src/main/java/com/example/chatserver/domain/readState/dto/payload/ReadStatePayload.java
@@ -1,6 +1,5 @@
 package com.example.chatserver.domain.readState.dto.payload;
 
-import com.example.chatserver.common.entity.ReadState;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/example/chatserver/domain/readState/dto/payload/ReadStatePayload.java
+++ b/src/main/java/com/example/chatserver/domain/readState/dto/payload/ReadStatePayload.java
@@ -1,0 +1,14 @@
+package com.example.chatserver.domain.readState.dto.payload;
+
+import com.example.chatserver.common.entity.ReadState;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReadStatePayload {
+
+    private Long roomId;
+    private Long readerId;
+    private Long lastReadMessageId;
+}

--- a/src/main/java/com/example/chatserver/domain/readState/dto/request/MarkReadRequest.java
+++ b/src/main/java/com/example/chatserver/domain/readState/dto/request/MarkReadRequest.java
@@ -1,0 +1,10 @@
+package com.example.chatserver.domain.readState.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class MarkReadRequest {
+
+    private Long roomId;
+    private Long userId;
+}

--- a/src/main/java/com/example/chatserver/domain/readState/repository/ReadStateRepository.java
+++ b/src/main/java/com/example/chatserver/domain/readState/repository/ReadStateRepository.java
@@ -1,0 +1,18 @@
+package com.example.chatserver.domain.readState.repository;
+
+import com.example.chatserver.common.entity.ChatRoom;
+import com.example.chatserver.common.entity.ReadState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ReadStateRepository extends JpaRepository<ReadState,Long> {
+
+    Optional<ReadState> findByChatRoomAndUserId(ChatRoom chatRoom, Long userId);
+
+    List<ReadState> findByChatRoomIdInAndUserId(Collection<Long> roomIds, Long userId);
+
+    List<ReadState> findByChatRoomIdInAndUserIdIn(Collection<Long> roomIds, Collection<Long> userIds);
+}

--- a/src/main/java/com/example/chatserver/domain/readState/service/ReadStateService.java
+++ b/src/main/java/com/example/chatserver/domain/readState/service/ReadStateService.java
@@ -1,0 +1,43 @@
+package com.example.chatserver.domain.readState.service;
+
+import com.example.chatserver.common.entity.ChatMessage;
+import com.example.chatserver.common.entity.ChatRoom;
+import com.example.chatserver.common.entity.ReadState;
+import com.example.chatserver.domain.chatMessage.repository.ChatMessageRepository;
+import com.example.chatserver.domain.chatRoom.repository.ChatRoomRepository;
+import com.example.chatserver.domain.readState.repository.ReadStateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReadStateService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ReadStateRepository readStateRepository;
+
+    // 읽음 처리
+    @Transactional
+    public Long markReadAll(Long roomId, Long userId) {
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalStateException("채팅방이 존재하지 않습니다."));
+
+        if (!userId.equals(room.getSellerId()) && !userId.equals(room.getBidderId())) {
+            throw new IllegalStateException("채팅방 참여자만 읽음 처리할 수 있습니다.");
+        }
+
+        Long lastMessageId = chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId)
+                .map(ChatMessage::getId)
+                .orElse(null);
+
+        ReadState state = readStateRepository.findByChatRoomAndUserId(room, userId)
+                .orElseGet(() -> readStateRepository.save(ReadState.create(room, userId)));
+
+        state.markRead(lastMessageId);
+
+        return lastMessageId;
+    }
+}

--- a/src/main/resources/static/chat-ui.html
+++ b/src/main/resources/static/chat-ui.html
@@ -1,0 +1,452 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <title>Chat UI (Safe)</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        :root { --border:#e6e6e6; --bg:#fafafa; --muted:#666; }
+        *{ box-sizing:border-box; }
+        body{ margin:0; font-family: Arial, sans-serif; background: var(--bg); }
+        .app{ display:flex; height:100vh; }
+        .left{ width:320px; border-right:1px solid var(--border); background:#fff; display:flex; flex-direction:column; }
+        .right{ flex:1; display:flex; flex-direction:column; }
+        .topbar{ padding:12px; border-bottom:1px solid var(--border); background:#fff; display:flex; gap:8px; align-items:flex-end; }
+        .topbar .field{ display:flex; flex-direction:column; gap:4px; }
+        .topbar input{ padding:8px; width:130px; }
+        .btn{ padding:8px 10px; border:1px solid var(--border); background:#fff; cursor:pointer; border-radius:6px; }
+        .rooms{ overflow:auto; padding:8px; }
+        .room{ border:1px solid var(--border); border-radius:10px; padding:10px; margin-bottom:8px; cursor:pointer; background:#fff; }
+        .room.active{ border-color:#111; }
+        .room .row{ display:flex; justify-content:space-between; align-items:center; gap:10px; }
+        .room .meta{ font-size:12px; color:var(--muted); margin-top:6px; }
+        .badge{ min-width:22px; height:22px; border-radius:11px; background:#111; color:#fff; font-size:12px;
+            display:flex; align-items:center; justify-content:center; padding:0 7px; }
+        .chatHeader{ padding:12px; border-bottom:1px solid var(--border); background:#fff; }
+        .chatHeader .title{ font-weight:700; }
+        .chatHeader .sub{ margin-top:4px; font-size:12px; color:var(--muted); }
+        .messages{ flex:1; overflow:auto; padding:14px; }
+        .msgRow{ display:flex; margin-bottom:10px; }
+        .msgRow.me{ justify-content:flex-end; }
+        .bubble{ max-width:62%; padding:10px 12px; border-radius:14px; border:1px solid var(--border); background:#fff; }
+        .msgRow.me .bubble{ background:#111; color:#fff; border-color:#111; }
+        .msgMeta{ margin-top:6px; font-size:11px; color:var(--muted); display:flex; justify-content:space-between; gap:10px; }
+        .msgRow.me .msgMeta{ color:#cfcfcf; }
+        .composer{ padding:12px; border-top:1px solid var(--border); background:#fff; display:flex; gap:8px; }
+        .composer input{ flex:1; padding:10px; border:1px solid var(--border); border-radius:10px; }
+        .log{ padding:10px; font-size:12px; color:var(--muted); border-top:1px solid var(--border); background:#fff; height:120px; overflow:auto; white-space:pre-wrap; }
+        .tiny{ font-size:12px; color:var(--muted); }
+        code{ background:#f3f3f3; padding:1px 4px; border-radius:4px; }
+    </style>
+</head>
+
+<body>
+<div class="app">
+
+    <div class="left">
+        <div class="topbar">
+            <div class="field">
+                <div class="tiny">userId (CONNECT 헤더 userId)</div>
+                <input id="userId" value="2">
+            </div>
+            <button class="btn" onclick="connect()">CONNECT</button>
+            <button class="btn" onclick="refreshRooms()">REFRESH</button>
+        </div>
+        <div class="rooms" id="rooms"></div>
+    </div>
+
+    <div class="right">
+        <div class="chatHeader" id="chatHeader">
+            <div class="title">채팅방을 선택해줘</div>
+            <div class="sub">좌측 목록 클릭 → 메시지 로드 + 자동 READ</div>
+        </div>
+
+        <div class="messages" id="messages"></div>
+
+        <div class="composer">
+            <input id="content" placeholder="메시지 입력..." onkeydown="if(event.key==='Enter') sendMessage()">
+            <button class="btn" onclick="sendMessage()">SEND</button>
+            <button class="btn" onclick="markRead()">READ</button>
+        </div>
+
+        <div class="log" id="log"></div>
+    </div>
+
+</div>
+
+<script>
+    // ===== configurable endpoints (너 프로젝트에 맞게 여기만 수정하면 됨) =====
+    const WS_ENDPOINT = "/ws";
+    const ROOMS_URL = (userId) => "/api/v2/chats/rooms/" + userId;
+    const MESSAGES_URL = (roomId, userId) => "/api/v2/chats/rooms/" + roomId + "/messages/" + userId;
+    // ================================================================
+
+    let stompClient = null;
+    let chatSub = null;
+    let readSub = null;
+
+    let me = null;
+    let currentRoomId = null;
+
+    let rooms = []; // [{roomId, lastMessageAt, unreadCount, otherLastReadMessageId}]
+    let messagesByRoom = {}; // roomId -> [{key,id,senderId,content,createdAt}]
+    let messageKeySetByRoom = {}; // roomId -> Set
+    let otherLastReadByRoom = {}; // roomId -> lastReadMessageId
+
+    function log(msg){
+        const el = document.getElementById("log");
+        el.textContent += msg + "\n";
+        el.scrollTop = el.scrollHeight;
+    }
+
+    function getUserId(){
+        const v = document.getElementById("userId").value.trim();
+        return v ? Number(v) : null;
+    }
+
+    function safeContentFromResponse(data){
+        if (Array.isArray(data)) return data;
+        if (data && Array.isArray(data.content)) return data.content;
+        // Slice가 다른 키를 쓰는 경우 대비
+        if (data && Array.isArray(data.contents)) return data.contents;
+        return [];
+    }
+
+    function normalizeRoom(raw){
+        return {
+            roomId: raw.roomId ?? raw.id ?? raw.room_id,
+            lastMessageAt: raw.lastMessageAt ?? raw.last_message_at ?? raw.createdAt ?? raw.created_at ?? null,
+            unreadCount: raw.unreadCount ?? raw.unread_count ?? 0,
+            otherLastReadMessageId: raw.otherLastReadMessageId ?? raw.other_last_read_message_id ?? null
+        };
+    }
+
+    function normalizeMessage(raw){
+        const id = raw.messageId ?? raw.id ?? raw.message_id ?? null;
+        const senderId = raw.senderId ?? raw.sender_id;
+        const content = raw.content ?? raw.message ?? "";
+        const createdAt = raw.createdAt ?? raw.created_at ?? "";
+
+        // id가 없을 때도 중복 제거를 위해 key를 만든다
+        const key = (id != null)
+            ? "id:" + id
+            : ("f:" + senderId + "|" + content + "|" + createdAt);
+
+        return { key: key, id: id, senderId: Number(senderId), content: String(content), createdAt: String(createdAt) };
+    }
+
+    function connect(){
+        const userId = getUserId();
+        if(!userId){ log("❌ userId 입력"); return; }
+        me = userId;
+
+        const socket = new SockJS(WS_ENDPOINT);
+        stompClient = Stomp.over(socket);
+        stompClient.debug = () => {}; // debug off
+
+        stompClient.connect(
+            { userId: String(userId) },
+            () => {
+                log("✅ CONNECTED as " + userId);
+                subscribeQueues();
+                refreshRooms();
+            },
+            (err) => log("❌ CONNECT ERROR: " + err)
+        );
+    }
+
+    function subscribeQueues(){
+        if(!stompClient || !stompClient.connected) return;
+
+        if(!chatSub){
+            chatSub = stompClient.subscribe("/user/queue/chat", (m) => {
+                const payload = JSON.parse(m.body);
+                onIncomingChat(payload);
+            });
+            log("✅ SUB /user/queue/chat");
+        }
+
+        if(!readSub){
+            readSub = stompClient.subscribe("/user/queue/read", (m) => {
+                const payload = JSON.parse(m.body);
+                onIncomingRead(payload);
+            });
+            log("✅ SUB /user/queue/read");
+        }
+    }
+
+    async function refreshRooms(){
+        const userId = getUserId();
+        if(!userId){ log("❌ userId 입력"); return; }
+
+        try{
+            const res = await fetch(ROOMS_URL(userId));
+            if(!res.ok){
+                log("❌ rooms fetch failed: " + res.status);
+                return;
+            }
+            const data = await res.json();
+            const content = safeContentFromResponse(data);
+
+            rooms = content.map(normalizeRoom)
+                .filter(r => r.roomId != null);
+
+            // cache other last read
+            for (let i = 0; i < rooms.length; i++) {
+                const r = rooms[i];
+                otherLastReadByRoom[r.roomId] = r.otherLastReadMessageId;
+            }
+
+            renderRooms();
+            log("✅ rooms loaded: " + rooms.length);
+
+        }catch(e){
+            log("❌ rooms fetch error: " + e);
+        }
+    }
+
+    function renderRooms(){
+        const el = document.getElementById("rooms");
+        el.innerHTML = "";
+
+        for(let i=0;i<rooms.length;i++){
+            const r = rooms[i];
+            const div = document.createElement("div");
+            div.className = "room" + (r.roomId === currentRoomId ? " active" : "");
+            div.onclick = () => openRoom(r.roomId);
+
+            const top = document.createElement("div");
+            top.className = "row";
+
+            const left = document.createElement("div");
+            left.innerHTML = "<b>Room #" + r.roomId + "</b>";
+
+            const right = document.createElement("div");
+            if(Number(r.unreadCount) > 0){
+                const b = document.createElement("div");
+                b.className = "badge";
+                b.textContent = String(r.unreadCount);
+                right.appendChild(b);
+            }
+
+            top.appendChild(left);
+            top.appendChild(right);
+
+            const meta = document.createElement("div");
+            meta.className = "meta";
+            meta.textContent = "last: " + (r.lastMessageAt ? r.lastMessageAt : "-");
+
+            div.appendChild(top);
+            div.appendChild(meta);
+
+            el.appendChild(div);
+        }
+    }
+
+    async function openRoom(roomId){
+        currentRoomId = roomId;
+
+        const header = document.getElementById("chatHeader");
+        header.innerHTML = `
+      <div class="title">Room #${roomId}</div>
+      <div class="sub">현재 userId=${me} / 자동 READ: <code>/app/read</code></div>
+    `;
+
+        renderRooms();
+        await loadMessages(roomId);
+        renderMessages(roomId);
+
+        // 방 들어오면 자동 읽음 처리
+        doMarkRead(roomId);
+    }
+
+    async function loadMessages(roomId){
+        const userId = getUserId();
+        if(!userId) return;
+
+        try{
+            const res = await fetch(MESSAGES_URL(roomId, userId));
+            if(!res.ok){
+                log("❌ messages fetch failed: " + res.status);
+                messagesByRoom[roomId] = [];
+                messageKeySetByRoom[roomId] = new Set();
+                return;
+            }
+            const data = await res.json();
+            const content = safeContentFromResponse(data);
+
+            const list = [];
+            const keySet = new Set();
+
+            // 서버가 desc로 주는 경우가 많으니 createdAt 있으면 정렬해서 올림차순으로 보여주자
+            for(let i=0;i<content.length;i++){
+                const nm = normalizeMessage(content[i]);
+                if(!keySet.has(nm.key)){
+                    keySet.add(nm.key);
+                    list.push(nm);
+                }
+            }
+
+            // createdAt이 있다면 정렬
+            list.sort((a,b) => String(a.createdAt).localeCompare(String(b.createdAt)));
+
+            messagesByRoom[roomId] = list;
+            messageKeySetByRoom[roomId] = keySet;
+
+            log("✅ messages loaded: " + list.length + " (room " + roomId + ")");
+        }catch(e){
+            log("❌ messages fetch error: " + e);
+            messagesByRoom[roomId] = [];
+            messageKeySetByRoom[roomId] = new Set();
+        }
+    }
+
+    function renderMessages(roomId){
+        const el = document.getElementById("messages");
+        el.innerHTML = "";
+
+        const list = messagesByRoom[roomId] || [];
+        const otherLastRead = otherLastReadByRoom[roomId] ?? null;
+
+        for(let i=0;i<list.length;i++){
+            const msg = list[i];
+
+            const row = document.createElement("div");
+            row.className = "msgRow" + (msg.senderId === me ? " me" : "");
+
+            const bubble = document.createElement("div");
+            bubble.className = "bubble";
+            bubble.textContent = msg.content;
+
+            const meta = document.createElement("div");
+            meta.className = "msgMeta";
+
+            const time = document.createElement("span");
+            time.textContent = msg.createdAt ? msg.createdAt : "";
+
+            const read = document.createElement("span");
+            if(msg.senderId === me){
+                const ok = (msg.id != null && otherLastRead != null && Number(msg.id) <= Number(otherLastRead));
+                read.textContent = ok ? "✓ 읽음" : "";
+            } else {
+                read.textContent = "";
+            }
+
+            meta.appendChild(time);
+            meta.appendChild(read);
+            bubble.appendChild(meta);
+            row.appendChild(bubble);
+            el.appendChild(row);
+        }
+
+        el.scrollTop = el.scrollHeight;
+    }
+
+    function bumpRoomToTop(roomId){
+        const idx = rooms.findIndex(r => r.roomId === roomId);
+        if(idx === -1) return;
+
+        const target = rooms[idx];
+        rooms.splice(idx, 1);
+        rooms.unshift(target);
+        renderRooms();
+    }
+
+    function addOrUpdateRoom(roomId, bump){
+        let idx = rooms.findIndex(r => r.roomId === roomId);
+        if(idx === -1){
+            rooms.unshift({ roomId: roomId, lastMessageAt: null, unreadCount: 0, otherLastReadMessageId: otherLastReadByRoom[roomId] ?? null });
+            idx = 0;
+        }
+        if(bump) bumpRoomToTop(roomId);
+    }
+
+    function onIncomingChat(payload){
+        // payload: ChatMessagePayload 형태 (roomId, senderId, content, createdAt?, messageId?)
+        const roomId = payload.roomId ?? payload.room_id;
+        if(roomId == null) return;
+
+        addOrUpdateRoom(roomId, true);
+
+        const msg = normalizeMessage(payload);
+
+        if(!messagesByRoom[roomId]){
+            messagesByRoom[roomId] = [];
+            messageKeySetByRoom[roomId] = new Set();
+        }
+
+        const keySet = messageKeySetByRoom[roomId];
+        if(!keySet.has(msg.key)){
+            keySet.add(msg.key);
+            messagesByRoom[roomId].push(msg);
+        }
+
+        // 현재 방이면 렌더 + 자동 READ
+        if(currentRoomId === roomId){
+            renderMessages(roomId);
+            doMarkRead(roomId);
+        } else {
+            // 내가 보낸 메시지 에코로 올 수도 있으니, "상대가 보낸 메시지"만 뱃지 증가
+            if(Number(msg.senderId) !== Number(me)){
+                const idx = rooms.findIndex(r => r.roomId === roomId);
+                if(idx !== -1) rooms[idx].unreadCount = Number(rooms[idx].unreadCount || 0) + 1;
+            }
+            renderRooms();
+        }
+
+        log("📩 chat recv room=" + roomId + " sender=" + msg.senderId);
+    }
+
+    function onIncomingRead(payload){
+        // payload: {roomId, readerId, lastReadMessageId}
+        const roomId = payload.roomId ?? payload.room_id;
+        const lastRead = payload.lastReadMessageId ?? payload.last_read_message_id;
+
+        if(roomId == null) return;
+        otherLastReadByRoom[roomId] = lastRead;
+
+        if(currentRoomId === roomId){
+            renderMessages(roomId);
+        }
+
+        log("👁️ read receipt room=" + roomId + " reader=" + (payload.readerId ?? payload.reader_id) + " last=" + lastRead);
+    }
+
+    function sendMessage(){
+        if(!stompClient || !stompClient.connected){ log("❌ 먼저 CONNECT"); return; }
+        if(!currentRoomId){ log("❌ 방 먼저 선택"); return; }
+
+        const content = document.getElementById("content").value.trim();
+        if(!content){ log("❌ content 입력"); return; }
+
+        const payload = { roomId: Number(currentRoomId), senderId: Number(me), content: content };
+        stompClient.send("/app/message", {}, JSON.stringify(payload));
+
+        // sender echo가 오기 때문에 로컬 append는 하지 않음 (중복 방지)
+        document.getElementById("content").value = "";
+        log("➡️ sent: " + JSON.stringify(payload));
+    }
+
+    function markRead(){
+        if(!currentRoomId){ log("❌ 방 먼저 선택"); return; }
+        doMarkRead(currentRoomId);
+    }
+
+    function doMarkRead(roomId){
+        if(!stompClient || !stompClient.connected) return;
+
+        const payload = { roomId: Number(roomId), userId: Number(me) };
+        stompClient.send("/app/read", {}, JSON.stringify(payload));
+
+        // UI상 즉시 0 처리
+        const idx = rooms.findIndex(r => r.roomId === roomId);
+        if(idx !== -1){
+            rooms[idx].unreadCount = 0;
+            renderRooms();
+        }
+        log("👁️ markRead sent: " + JSON.stringify(payload));
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/static/test-ws.html
+++ b/src/main/resources/static/test-ws.html
@@ -2,46 +2,92 @@
 <html lang="ko">
 <head>
     <meta charset="utf-8" />
-    <title>WebSocket Test (SockJS + STOMP)</title>
+    <title>Chat WS Test (SockJS + STOMP)</title>
+
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+
     <style>
-        body { font-family: Arial, sans-serif; }
-        input { width: 220px; margin: 4px 0; }
-        button { margin-right: 6px; }
-        pre { background: #f6f6f6; padding: 10px; height: 260px; overflow: auto; }
-        .row { margin-bottom: 8px; }
+        body { font-family: Arial, sans-serif; margin: 18px; }
+        h2 { margin-top: 0; }
+        .grid { display: grid; grid-template-columns: 240px 1fr; gap: 10px; max-width: 980px; }
+        .box { border: 1px solid #ddd; padding: 12px; border-radius: 8px; }
+        label { display: block; font-size: 13px; margin-top: 8px; }
+        input { width: 100%; padding: 8px; box-sizing: border-box; }
+        button { margin-top: 10px; margin-right: 6px; padding: 8px 10px; }
+        pre { background: #f6f6f6; padding: 10px; height: 360px; overflow: auto; border-radius: 6px; }
+        .row { margin-top: 6px; }
+        .hint { color: #666; font-size: 12px; margin-top: 6px; }
     </style>
 </head>
+
 <body>
-<h2>WebSocket Test</h2>
+<h2>Chat WebSocket Test</h2>
 
-<div class="row">
-    <div>roomId</div>
-    <input id="roomId" value="1" />
+<div class="grid">
+
+    <!-- LEFT: Controls -->
+    <div class="box">
+        <div class="row">
+            <label>WS Endpoint (SockJS)</label>
+            <input id="wsEndpoint" value="/ws" />
+            <div class="hint">서버에서 <code>addEndpoint("/ws").withSockJS()</code>라면 그대로 /ws</div>
+        </div>
+
+        <div class="row">
+            <label>roomId</label>
+            <input id="roomId" value="1" />
+        </div>
+
+        <div class="row">
+            <label>userId (CONNECT 헤더 userId, = Principal name 임시)</label>
+            <input id="userId" value="2" />
+            <div class="hint">브라우저 탭을 2개 열어서 userId를 1/2로 바꿔 테스트하면 됨</div>
+        </div>
+
+        <div class="row">
+            <label>content</label>
+            <input id="content" placeholder="message..." />
+        </div>
+
+        <div class="row">
+            <button onclick="connect()">CONNECT</button>
+            <button onclick="disconnect()">DISCONNECT</button>
+        </div>
+
+        <div class="row">
+            <button onclick="subscribeChat()">SUBSCRIBE CHAT<br><small>(/user/queue/chat)</small></button>
+            <button onclick="subscribeRead()">SUBSCRIBE READ<br><small>(/user/queue/read)</small></button>
+        </div>
+
+        <div class="row">
+            <button onclick="sendMessage()">SEND MESSAGE<br><small>(/app/message)</small></button>
+            <button onclick="markRead()">MARK READ<br><small>(/app/read)</small></button>
+        </div>
+
+        <div class="hint">
+            ✅ 테스트 순서 추천<br>
+            1) 탭A userId=1 CONNECT + SUBSCRIBE CHAT/READ<br>
+            2) 탭B userId=2 CONNECT + SUBSCRIBE CHAT/READ<br>
+            3) 탭B에서 SEND → 탭A에 메시지 수신<br>
+            4) 탭A에서 MARK READ → 탭B에 READ receipt 수신
+        </div>
+    </div>
+
+    <!-- RIGHT: Log -->
+    <div class="box">
+        <div class="row">
+            <button onclick="clearLog()">CLEAR LOG</button>
+        </div>
+        <pre id="log"></pre>
+    </div>
+
 </div>
-
-<div class="row">
-    <div>senderId (CONNECT userId 헤더로도 사용됨)</div>
-    <input id="senderId" value="2" />
-</div>
-
-<div class="row">
-    <div>content</div>
-    <input id="content" placeholder="message..." />
-</div>
-
-<div class="row">
-    <button onclick="connect()">CONNECT</button>
-    <button onclick="subscribeUserQueue()">SUBSCRIBE (/user/queue/chat)</button>
-    <button onclick="sendMsg()">SEND (/app/message)</button>
-    <button onclick="disconnect()">DISCONNECT</button>
-</div>
-
-<pre id="log"></pre>
 
 <script>
     let stompClient = null;
+    let chatSubscription = null;
+    let readSubscription = null;
 
     function log(msg) {
         const el = document.getElementById("log");
@@ -49,23 +95,34 @@
         el.scrollTop = el.scrollHeight;
     }
 
+    function clearLog() {
+        document.getElementById("log").textContent = "";
+    }
+
+    function getVal(id) {
+        return document.getElementById(id).value.trim();
+    }
+
     function connect() {
-        const senderId = document.getElementById("senderId").value.trim();
-        if (!senderId) {
-            log("❌ senderId를 입력해줘");
+        const endpoint = getVal("wsEndpoint");
+        const userId = getVal("userId");
+
+        if (!endpoint) {
+            log("❌ wsEndpoint를 입력해줘");
+            return;
+        }
+        if (!userId) {
+            log("❌ userId를 입력해줘");
             return;
         }
 
-        // ✅ SockJS endpoint (서버: registry.addEndpoint("/ws").withSockJS())
-        const socket = new SockJS("/ws");
-
+        const socket = new SockJS(endpoint);
         stompClient = Stomp.over(socket);
 
-        // (선택) 로그 너무 많으면 주석
+        // debug 로그가 너무 많으면 아래 줄 주석 처리
         stompClient.debug = (str) => console.log(str);
 
-        // ✅ TestUserChannelInterceptor가 CONNECT 헤더 userId로 Principal 세팅함
-        const headers = { userId: senderId };
+        const headers = { userId: userId };
 
         stompClient.connect(
             headers,
@@ -74,52 +131,105 @@
         );
     }
 
-    function subscribeUserQueue() {
-        if (!stompClient || !stompClient.connected) {
-            log("❌ 먼저 CONNECT 해줘");
-            return;
-        }
-
-        // ✅ user destination 구독
-        // 서버가 convertAndSendToUser("3", "/queue/chat", ...) 하면
-        // 클라는 /user/queue/chat 로 받아야 함
-        stompClient.subscribe("/user/queue/chat", (message) => {
-            log("📩 RECV: " + message.body);
-        });
-
-        log("✅ SUBSCRIBED: /user/queue/chat");
-    }
-
-    function sendMsg() {
-        if (!stompClient || !stompClient.connected) {
-            log("❌ 먼저 CONNECT 해줘");
-            return;
-        }
-
-        const roomId = Number(document.getElementById("roomId").value);
-        const senderId = Number(document.getElementById("senderId").value);
-        const content = document.getElementById("content").value;
-
-        if (!roomId || !senderId || !content) {
-            log("❌ roomId, senderId, content를 모두 입력해줘");
-            return;
-        }
-
-        const payload = { roomId, senderId, content };
-
-        // ✅ 서버 @MessageMapping("/message") 라면 클라는 /app/message 로 SEND
-        stompClient.send("/app/message", {}, JSON.stringify(payload));
-
-        log("➡️ SENT: " + JSON.stringify(payload));
-    }
-
     function disconnect() {
+        if (chatSubscription) {
+            chatSubscription.unsubscribe();
+            chatSubscription = null;
+        }
+        if (readSubscription) {
+            readSubscription.unsubscribe();
+            readSubscription = null;
+        }
+
         if (stompClient && stompClient.connected) {
             stompClient.disconnect(() => log("✅ DISCONNECTED"));
         } else {
             log("ℹ️ 이미 disconnected 상태");
         }
     }
+
+    function subscribeChat() {
+        if (!stompClient || !stompClient.connected) {
+            log("❌ 먼저 CONNECT 해줘");
+            return;
+        }
+        if (chatSubscription) {
+            log("ℹ️ 이미 CHAT 구독 중");
+            return;
+        }
+
+        chatSubscription = stompClient.subscribe("/user/queue/chat", (message) => {
+            log("📩 CHAT RECV: " + message.body);
+        });
+
+        log("✅ SUBSCRIBED: /user/queue/chat");
+    }
+
+    function subscribeRead() {
+        if (!stompClient || !stompClient.connected) {
+            log("❌ 먼저 CONNECT 해줘");
+            return;
+        }
+        if (readSubscription) {
+            log("ℹ️ 이미 READ 구독 중");
+            return;
+        }
+
+        readSubscription = stompClient.subscribe("/user/queue/read", (message) => {
+            log("👁️ READ RECEIPT RECV: " + message.body);
+        });
+
+        log("✅ SUBSCRIBED: /user/queue/read");
+    }
+
+    function sendMessage() {
+        if (!stompClient || !stompClient.connected) {
+            log("❌ 먼저 CONNECT 해줘");
+            return;
+        }
+
+        const roomIdStr = getVal("roomId");
+        const userIdStr = getVal("userId");
+        const content = getVal("content");
+
+        const roomId = Number(roomIdStr);
+        const senderId = Number(userIdStr);
+
+        if (!roomId || !senderId || !content) {
+            log("❌ roomId, userId, content를 모두 입력해줘");
+            return;
+        }
+
+        const payload = { roomId: roomId, senderId: senderId, content: content };
+
+        stompClient.send("/app/message", {}, JSON.stringify(payload));
+        log("➡️ SENT /app/message: " + JSON.stringify(payload));
+    }
+
+    function markRead() {
+        if (!stompClient || !stompClient.connected) {
+            log("❌ 먼저 CONNECT 해줘");
+            return;
+        }
+
+        const roomIdStr = getVal("roomId");
+        const userIdStr = getVal("userId");
+
+        const roomId = Number(roomIdStr);
+        const userId = Number(userIdStr);
+
+        if (!roomId || !userId) {
+            log("❌ roomId, userId를 입력해줘");
+            return;
+        }
+
+        // 서버 @MessageMapping("/read") + DTO {roomId, userId}
+        const payload = { roomId: roomId, userId: userId };
+
+        stompClient.send("/app/read", {}, JSON.stringify(payload));
+        log("👁️ SENT /app/read: " + JSON.stringify(payload));
+    }
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
## PR 체크리스트
### 아래 사항을 확인하고 체크해주세요.
- [ ] 코드가 명확하고 읽기 쉬운가
- [ ] 변수 및 함수 이름이 의도를 잘 반영하고 있는가
- [ ] 불필요한 중복 코드는 없는가
- [ ] 클래스에 대한 적절한 주석이나 문서화가 포함되어 있는가
- [ ] 팀 코드 컨벤션 가이드라인을 준수하는가
## 티켓 번호
<!-- 아래에 할당된 티켓 번호를 적어주세요 -->
```
close #11 
```

## 작업 사항
- 최근 채팅 순으로 채팅방 정렬
  - ChatRoom 엔티티에 `last_message_at` 필드 추가
- 읽음 처리 로직
  - ReadState 엔티티 추가
  - 메서드 호출 때마다 마지막으로 읽은 메시지 Update
  - `lastReadMessage` 기준으로 프론트에서 읽음 표시 가능하도록 구현
  - 스크롤 기준 (X) 채팅방에 입장하면 모두 읽은 것으로 처리 (O)
- 읽지 않은 메시지 수 계산
  - 메시지가 도착할 때마다 + 1
  - 채팅방에 입장하면 0으로 초기화
<img width="957" height="245" alt="image" src="https://github.com/user-attachments/assets/1f3808ae-b680-42d8-84d3-90b099f9badb" />
<img width="957" height="245" alt="image" src="https://github.com/user-attachments/assets/5a7e7113-c00b-4f34-a42b-9120f124e973" />

## 기타 이슈
<!-- 기타 이슈에 대한 내용을 적어주세요 -->
`ChatRoomService`의 `getMyRooms` 메서드에서 N+1 없이 가져오려고 무한 매핑을 했는데 이 부분 위주로 봐주시면 감사하겠습니다 ..
- 내가 참여한 채팅방 목록을 최근 메시지 순으로 가져옴
- 그 방들에 대해 내 ReadState과 상대 ReadState를 IN 쿼리를 통해 한번에 가져옴
- 방마다 Map에서 읽음 정보를 꺼내 DTO로 변환 후 반환